### PR TITLE
21

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -82,7 +82,6 @@ trigger:
     - main
   event:
     - push
-    - tag
 
 # Test java-docker images
 steps:
@@ -96,6 +95,7 @@ steps:
         - push
     commands:
       - "uname -a"
+      - "cat /etc/os-release"
       - "java -version"
       - "javac src/hello-world/HelloWorld.java"
       - "java -classpath src/hello-world HelloWorld"
@@ -110,8 +110,72 @@ steps:
         - push
     commands:
       - "uname -a"
+      - "cat /etc/os-release"
       - "java -version"
       - "java -classpath src/hello-world HelloWorld"
+
+  # Slack notification
+  - name: slack-notification
+    image: plugins/slack
+    when:
+      status:
+        - failure
+        - success
+    settings:
+      webhook:
+        from_secret: slack_webhook_drone_alerts
+
+---
+
+kind: pipeline
+type: docker
+name: java-image-tag
+
+trigger:
+  event:
+    - tag
+
+# Build the jdk and jre docker images for amd64 architecture
+steps:
+  # Build JDK image
+  - name: docker-build-jdk
+    image: plugins/docker
+    environment:
+      DOCKER_BUILDKIT: 1
+    when:
+      event:
+        - tag
+    settings:
+      platforms:
+        - linux/amd64
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      dockerfile: jdk/Dockerfile
+      repo: kernel528/java
+      tags:
+        - jdk-${DRONE_TAG}
+
+  # Build JRE Image
+  - name: docker-build-jre
+    image: plugins/docker
+    environment:
+      DOCKER_BUILDKIT: 1
+    when:
+      event:
+        - tag
+    settings:
+      platforms:
+        - linux/amd64
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      dockerfile: jre/Dockerfile
+      repo: kernel528/java
+      tags:
+        - jre-${DRONE_TAG}
 
   # Slack notification
   - name: slack-notification

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,7 +29,7 @@ steps:
       password:
         from_secret: docker_password
       dockerfile: jdk/Dockerfile
-      repo: kernel528/java
+      repo: kernel528/jdk
       tags:
         - jdk-latest
         - jdk21.0.5-11
@@ -53,7 +53,7 @@ steps:
       password:
         from_secret: docker_password
       dockerfile: jre/Dockerfile
-      repo: kernel528/java
+      repo: kernel528/jre
       tags:
         - jre-latest
         - jre21.0.5-11
@@ -87,7 +87,7 @@ trigger:
 steps:
   # Test JDK Image
   - name: docker-test-jdk
-    image: kernel528/java:jdk-latest
+    image: kernel528/jdk:jdk-latest
     when:
       branch:
         - main
@@ -102,7 +102,7 @@ steps:
 
   # Test JRE Image
   - name: docker-test-jre
-    image: kernel528/java:jre-latest
+    image: kernel528/jre:jre-latest
     when:
       branch:
         - main
@@ -153,7 +153,7 @@ steps:
       password:
         from_secret: docker_password
       dockerfile: jdk/Dockerfile
-      repo: kernel528/java
+      repo: kernel528/jdk
       tags:
         - jdk-${DRONE_TAG}
 
@@ -173,7 +173,7 @@ steps:
       password:
         from_secret: docker_password
       dockerfile: jre/Dockerfile
-      repo: kernel528/java
+      repo: kernel528/jre
       tags:
         - jre-${DRONE_TAG}
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-[![Build Status](http://drone.kernelsanders.biz:8080/api/badges/kernel528/java-docker/status.svg)](http://drone.kernelsanders.biz:8080/kernel528/java-docker)
-[![Latest Version](https://img.shields.io/github/v/tag/kernel528/java-docker)](https://github.com/kernel528/java-docker/releases/latest)
-[![Docker Pulls](https://img.shields.io/docker/pulls/kernel528/java)](https://hub.docker.com/r/kernel528/java)
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/java/jdk-latest)](https://hub.docker.com/r/kernel528/java/jdk-latest)
-[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/java/jre-latest)](https://hub.docker.com/r/kernel528/java/jre-latest)
-[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/kernel528/java?sort=semver)](https://hub.docker.com/r/kernel528/java)
+_[![Build Status](http://drone.kernelsanders.biz:8080/api/badges/kernel528/java-docker/status.svg)](http://drone.kernelsanders.biz:8080/kernel528/java-docker)_
+_[![Latest Version](https://img.shields.io/github/v/tag/kernel528/java-docker)](https://github.com/kernel528/java-docker/releases/latest)_
+
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/jdk/jdk-latest)](https://hub.docker.com/r/kernel528/jdk/jdk-latest)
+[![Docker Image Version (latest jdk semver)](https://img.shields.io/docker/v/kernel528/jdk?sort=semver)](https://hub.docker.com/r/kernel528/jdk)
+
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/kernel528/jre/jre-latest)](https://hub.docker.com/r/kernel528/jre/jre-latest)
+[![Docker Image Version (latest jre semver)](https://img.shields.io/docker/v/kernel528/jre?sort=semver)](https://hub.docker.com/r/kernel528/jre)
+
 
 # Java Docker
 ### Source repo to build the JDK and JRE docker images.
 - These can be called as such:
-  - JDK:  kernel528/jdk:latest
-  - JRE:  kernel528/jre:latest
+  - JDK:  kernel528/jdk:jdk-latest
+  - JRE:  kernel528/jre:jre-latest
 
 ### Comments
 - This image uses the kernel528/alpine as the base image (https://github.com/kernel528/alpine-docker)


### PR DESCRIPTION
- Updated README.md badges to new separate jdk and jre links.  
- Updated .drone.yml to publish jdk and jre docker images to separate repo instead of combined into kernel528/java.