### PR TITLE
Update to Temurin 25.0.3+9 on kernel528/alpine:3.24.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,8 +32,8 @@ steps:
       repo: kernel528/jdk
       tags:
         - jdk-latest
-        - jdk25.0.2-10_3.23.3
-        - jdk25.0.2-10_3.23.3-drone-build-${DRONE_BUILD_NUMBER}
+        - jdk25.0.3-9_3.24.1
+        - jdk25.0.3-9_3.24.1-drone-build-${DRONE_BUILD_NUMBER}
 
   # Build JRE Image
   - name: docker-build-jre
@@ -56,8 +56,8 @@ steps:
       repo: kernel528/jre
       tags:
         - jre-latest
-        - jre25.0.2-10_3.23.3
-        - jre25.0.2-10_3.23.3-drone-build-${DRONE_BUILD_NUMBER}
+        - jre25.0.3-9_3.24.1
+        - jre25.0.3-9_3.24.1-drone-build-${DRONE_BUILD_NUMBER}
 
   # Slack notification
   - name: slack-notification

--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ Source repo to build the JDK and JRE images.
 ## Overview
 - Base image: `kernel528/alpine` (https://github.com/kernel528/alpine-docker)
 - Upstream reference:
-  - JDK: https://github.com/adoptium/containers/blob/main/25/jdk/alpine/3.23/Dockerfile
-  - JRE: https://github.com/adoptium/containers/blob/main/25/jre/alpine/3.23/Dockerfile
+  - JDK: https://github.com/adoptium/containers/blob/main/25/jdk/alpine/3.24/Dockerfile
+  - JRE: https://github.com/adoptium/containers/blob/main/25/jre/alpine/3.24/Dockerfile
 - The Adoptium alpine Dockerfiles are the primary source for updates.
 - Drone builds and publishes images on merge/tag events.
 
 ## Build
 ```
 docker build -t kernel528/jdk:jdk-latest -f jdk/Dockerfile .
-docker build -t kernel528/jdk:jdk25.0.2-10_3.23.3 -f jdk/Dockerfile .
+docker build -t kernel528/jdk:jdk25.0.3-9_3.24.1 -f jdk/Dockerfile .
 docker build -t kernel528/jre:jre-latest -f jre/Dockerfile .
-docker build -t kernel528/jre:jre25.0.2-10_3.23.3 -f jre/Dockerfile .
+docker build -t kernel528/jre:jre25.0.3-9_3.24.1 -f jre/Dockerfile .
 ```
 
 ## CI tags
 Drone publishes tags like:
-- `jdk25.0.2-10_3.23.3`, `jdk25.0.2-10_3.23.3-drone-build-<build>`
-- `jre25.0.2-10_3.23.3`, `jre25.0.2-10_3.23.3-drone-build-<build>`
+- `jdk25.0.3-9_3.24.1`, `jdk25.0.3-9_3.24.1-drone-build-<build>`
+- `jre25.0.3-9_3.24.1`, `jre25.0.3-9_3.24.1-drone-build-<build>`
 
 Source of truth: `.drone.yml`. To list current tags quickly:
 ```
@@ -52,7 +52,7 @@ Or use the helper script:
 - If the base image changes, update `FROM kernel528/alpine:<tag>` in both Dockerfiles.
 - Keep `.drone.yml`, `README.md`, and `VERSION.md` aligned with the new tags.
 
-Current base image: `kernel528/alpine:3.23.3`.
+Current base image: `kernel528/alpine:3.24.1`.
 
 ## CA certificates
 - Set `USE_SYSTEM_CA_CERTS=1` to import system and custom certs at startup.

--- a/VERSION.md
+++ b/VERSION.md
@@ -19,3 +19,4 @@ Notes:
 - v25.0.1-8_3.23.2: Base image update to kernel528/alpine:3.23.2 and adoptium/containers v25.
 - v25.0.1-8_3.23.3: Base image update to kernel528/alpine:3.23.3.
 - v25.0.2-10_3.23.3: Updated to Temurin 25.0.2+10 on kernel528/alpine:3.23.3.
+- v25.0.3-9_3.24.1: Updated to Temurin 25.0.3+9 on kernel528/alpine:3.24.1.

--- a/jdk/Dockerfile
+++ b/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.23.3
+FROM kernel528/alpine:3.24.1
 
 # Set to root user to install packages
 USER root
@@ -32,18 +32,18 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION=jdk-25.0.2+10
+ENV JAVA_VERSION=jdk-25.0.3+9
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64) \
-         ESUM='e8d928fb018eabb31a148ebadaa5a5ec69273e6562afede21c426960a6a67143'; \
-         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_aarch64_alpine-linux_hotspot_25.0.2_10.tar.gz'; \
+         ESUM='6ed368e93049d3b188c045fce0b20953bbea92fe0614dbbf4d3fd8daad7be3b2'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_alpine-linux_hotspot_25.0.3_9.tar.gz'; \
          ;; \
        x86_64) \
-         ESUM='961f13ba0ee1e18c41c50ab642361e4283dee5e7947a48ed6a72c8a661d0cca0'; \
-         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jdk_x64_alpine-linux_hotspot_25.0.2_10.tar.gz'; \
+         ESUM='51c2415b370aac7c3796b0c4663c8fcf91bc22d76f03df95b25fa5667cb5fdd8'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_alpine-linux_hotspot_25.0.3_9.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/jre/Dockerfile
+++ b/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.23.3
+FROM kernel528/alpine:3.24.1
 
 USER root
 
@@ -28,18 +28,18 @@ RUN set -eux; \
     ; \
     rm -rf /var/cache/apk/*
 
-ENV JAVA_VERSION=jdk-25.0.2+10
+ENV JAVA_VERSION=jdk-25.0.3+9
 
 RUN set -eux; \
     ARCH="$(apk --print-arch)"; \
     case "${ARCH}" in \
        aarch64) \
-         ESUM='159099235c536b152f86111a694a8a03392948924736f354c79e95532dcfc1f8'; \
-         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jre_aarch64_alpine-linux_hotspot_25.0.2_10.tar.gz'; \
+         ESUM='48aa0908d9f4d501c1070ebbc8a4da93ca1f066c41ff2e34a22a34dd3ca2dac1'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_aarch64_alpine-linux_hotspot_25.0.3_9.tar.gz'; \
          ;; \
        x86_64) \
-         ESUM='2cbb356c6923f89814b892561e6f0377ecf035ab0577e3162d2cf4e202d38ee7'; \
-         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.2%2B10/OpenJDK25U-jre_x64_alpine-linux_hotspot_25.0.2_10.tar.gz'; \
+         ESUM='ad202c8f8b216800ed0d6581130f92e5680b685ba394ba38e62e7605c3fd9494'; \
+         BINARY_URL='https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_alpine-linux_hotspot_25.0.3_9.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \


### PR DESCRIPTION
## Changes

- **Java**: `25.0.2+10` → `25.0.3+9` (latest Temurin release)
- **Base image**: `kernel528/alpine:3.23.3` → `kernel528/alpine:3.24.1`
- **Upstream references**: Adoptium containers `alpine/3.23` → `alpine/3.24`
- Updated ESUMs and BINARY_URLs for both JDK and JRE
- Updated `.drone.yml`, `README.md`, `VERSION.md` with new version tags

## Validation

- [x] JDK image built successfully
- [x] JRE image built successfully
- [x] JDK smoke test: `java -version` → `openjdk 25.0.3 2026-04-21 LTS`
- [x] JRE smoke test: `java -version` → `openjdk 25.0.3 2026-04-21 LTS`
- GPG signature verification passed for both downloads
- SHA256 checksums verified for both downloads