### PR TITLE
Rebase Java 25 images on Alpine 3.24.1_1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,8 +32,8 @@ steps:
       repo: kernel528/jdk
       tags:
         - jdk-latest
-        - jdk25.0.3-9_3.24.1
-        - jdk25.0.3-9_3.24.1-drone-build-${DRONE_BUILD_NUMBER}
+        - jdk25.0.3-9_3.24.1_1
+        - jdk25.0.3-9_3.24.1_1-drone-build-${DRONE_BUILD_NUMBER}
 
   # Build JRE Image
   - name: docker-build-jre
@@ -56,8 +56,8 @@ steps:
       repo: kernel528/jre
       tags:
         - jre-latest
-        - jre25.0.3-9_3.24.1
-        - jre25.0.3-9_3.24.1-drone-build-${DRONE_BUILD_NUMBER}
+        - jre25.0.3-9_3.24.1_1
+        - jre25.0.3-9_3.24.1_1-drone-build-${DRONE_BUILD_NUMBER}
 
   # Slack notification
   - name: slack-notification

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ Source repo to build the JDK and JRE images.
 ## Build
 ```
 docker build -t kernel528/jdk:jdk-latest -f jdk/Dockerfile .
-docker build -t kernel528/jdk:jdk25.0.3-9_3.24.1 -f jdk/Dockerfile .
+docker build -t kernel528/jdk:jdk25.0.3-9_3.24.1_1 -f jdk/Dockerfile .
 docker build -t kernel528/jre:jre-latest -f jre/Dockerfile .
-docker build -t kernel528/jre:jre25.0.3-9_3.24.1 -f jre/Dockerfile .
+docker build -t kernel528/jre:jre25.0.3-9_3.24.1_1 -f jre/Dockerfile .
 ```
 
 ## CI tags
 Drone publishes tags like:
-- `jdk25.0.3-9_3.24.1`, `jdk25.0.3-9_3.24.1-drone-build-<build>`
-- `jre25.0.3-9_3.24.1`, `jre25.0.3-9_3.24.1-drone-build-<build>`
+- `jdk25.0.3-9_3.24.1_1`, `jdk25.0.3-9_3.24.1_1-drone-build-<build>`
+- `jre25.0.3-9_3.24.1_1`, `jre25.0.3-9_3.24.1_1-drone-build-<build>`
 
 Source of truth: `.drone.yml`. To list current tags quickly:
 ```
@@ -52,7 +52,7 @@ Or use the helper script:
 - If the base image changes, update `FROM kernel528/alpine:<tag>` in both Dockerfiles.
 - Keep `.drone.yml`, `README.md`, and `VERSION.md` aligned with the new tags.
 
-Current base image: `kernel528/alpine:3.24.1`.
+Current base image: `kernel528/alpine:3.24.1_1`.
 
 ## CA certificates
 - Set `USE_SYSTEM_CA_CERTS=1` to import system and custom certs at startup.

--- a/VERSION.md
+++ b/VERSION.md
@@ -20,3 +20,4 @@ Notes:
 - v25.0.1-8_3.23.3: Base image update to kernel528/alpine:3.23.3.
 - v25.0.2-10_3.23.3: Updated to Temurin 25.0.2+10 on kernel528/alpine:3.23.3.
 - v25.0.3-9_3.24.1: Updated to Temurin 25.0.3+9 on kernel528/alpine:3.24.1.
+- v25.0.3-9_3.24.1_1: Rebuilt Temurin 25.0.3+9 on kernel528/alpine:3.24.1_1.

--- a/jdk/Dockerfile
+++ b/jdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.24.1
+FROM kernel528/alpine:3.24.1_1
 
 # Set to root user to install packages
 USER root

--- a/jre/Dockerfile
+++ b/jre/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.24.1
+FROM kernel528/alpine:3.24.1_1
 
 USER root
 


### PR DESCRIPTION
## Summary
- rebase Temurin JDK and JRE 25.0.3+9 images on kernel528/alpine:3.24.1_1
- update immutable image tags, Drone outputs, README, and version history
- retain existing JDK/JRE application version and verified upstream artifacts

## Validation
- built JDK for linux/amd64 with no cache
- built JRE for linux/amd64 with no cache
- verified Adoptium GPG signatures and SHA256 checksums during both builds
- ran java -version successfully in both images

## Published base
- kernel528/alpine:3.24.1_1
- Docker manifest digest: sha256:1741c5bedfaafd75d3783ad6c51a0a604c52d8ee7eb40e6d083ad9aa3a88c2d6